### PR TITLE
Add newest version of gtfs-realtime.proto

### DIFF
--- a/gtfs-realtime.proto
+++ b/gtfs-realtime.proto
@@ -46,6 +46,9 @@ message FeedMessage {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Metadata about a feed, included in feed messages.
@@ -74,6 +77,9 @@ message FeedHeader {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A definition (or update) of an entity in the transit feed.
@@ -102,6 +108,9 @@ message FeedEntity {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -180,6 +189,9 @@ message TripUpdate {
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Realtime update for arrival and/or departure events for a given stop on a
@@ -204,7 +216,8 @@ message TripUpdate {
       // stops, although not necessarily according to the times of the schedule.
       // At least one of arrival and departure must be provided. If the schedule
       // for this stop contains both arrival and departure times then so must
-      // this update.
+      // this update. Frequency-based trips (GTFS frequencies.txt with exact_times = 0)
+      // should not have a SCHEDULED value and should use UNSCHEDULED instead.
       SCHEDULED = 0;
 
       // The stop is skipped, i.e., the vehicle will not stop at this stop.
@@ -217,6 +230,14 @@ message TripUpdate {
       // stops in the trip are considered to be unspecified as well.
       // Neither arrival nor departure should be supplied.
       NO_DATA = 2;
+      
+      // The vehicle is operating a trip defined in GTFS frequencies.txt with exact_times = 0.
+      // This value should not be used for trips that are not defined in GTFS frequencies.txt,
+      // or trips in GTFS frequencies.txt with exact_times = 1. Trips containing StopTimeUpdates
+      // with ScheduleRelationship=UNSCHEDULED must also set TripDescriptor.ScheduleRelationship=UNSCHEDULED.
+      // NOTE: This field is still experimental, and subject to change. It may be
+      // formally adopted in the future.
+      UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
@@ -225,6 +246,9 @@ message TripUpdate {
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Updates to StopTimes for the trip (both future, i.e., predictions, and in
@@ -276,6 +300,9 @@ message TripUpdate {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Realtime positioning information for a given vehicle.
@@ -370,6 +397,9 @@ message VehiclePosition {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An alert, indicating some sort of incident in the public transit network.
@@ -416,6 +446,7 @@ message Alert {
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
     NO_EFFECT = 10;
+    ACCESSIBILITY_ISSUE = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 
@@ -452,6 +483,9 @@ message Alert {
   // GTFS Realtime Specification in order to add and evaluate new features
   // and modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -475,6 +509,9 @@ message TimeRange {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A position.
@@ -501,6 +538,9 @@ message Position {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A descriptor that identifies an instance of a GTFS trip, or all instances of
@@ -569,8 +609,8 @@ message TripDescriptor {
     // load.
     ADDED = 1;
 
-    // A trip that is running with no schedule associated to it, for example, if
-    // there is no schedule at all.
+    // A trip that is running with no schedule associated to it (GTFS frequencies.txt exact_times=0).
+    // Trips with ScheduleRelationship=UNSCHEDULED must also set all StopTimeUpdates.ScheduleRelationship=UNSCHEDULED.
     UNSCHEDULED = 2;
 
     // A trip that existed in the schedule but was removed.
@@ -585,6 +625,9 @@ message TripDescriptor {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Identification information for the vehicle performing the trip.
@@ -605,6 +648,9 @@ message VehicleDescriptor {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A selector for an entity in a GTFS feed.
@@ -619,11 +665,18 @@ message EntitySelector {
   optional int32 route_type = 3;
   optional TripDescriptor trip = 4;
   optional string stop_id = 5;
+  // Corresponds to trip direction_id in GTFS trips.txt. If provided the
+  // route_id must also be provided. This field is still experimental, and
+  // subject to change. It may be formally adopted in the future.
+  optional uint32 direction_id = 6;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An internationalized message containing per-language versions of a snippet of
@@ -649,6 +702,9 @@ message TranslatedString {
     // GTFS Realtime Specification in order to add and evaluate new features and
     // modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
   // At least one translation must be provided.
   repeated Translation translation = 1;
@@ -657,4 +713,7 @@ message TranslatedString {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,6 +65,14 @@
     </dependencies>
 
     <build>
+        <resources>
+          <resource>
+              <directory>../</directory>
+                  <includes>
+                      <include>gtfs-realtime.proto</include>
+                  </includes>
+              </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Since this repo has been started, the proto file has received a few additions, which I'm interested in, so I added them.

Would you like me to generate the code as well or should that happen after the PR has been merged? For Java, which is what I'm interested in, I can do it easily. For the rest I'm not so sure.