### PR TITLE
Update resource path for gtfs-realtime.proto in Java POM

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,6 +68,7 @@
         <resources>
             <resource>
                 <directory>../</directory>
+                <targetPath>com/google/transit/realtime</targetPath>
                 <includes>
                     <include>gtfs-realtime.proto</include>
                 </includes>


### PR DESCRIPTION
In order to be able to build extensions using the copy of `gtfs-realtime.proto` in the built JAR, it needs to end up at `com/google/transit/realtime` (which is where extension `.proto` files would expect to find it). This PR updates the resource directory definition in the POM to add a `targetPath` so that this is accomplished.