### PR TITLE
corrected symbol name according to definition in gtfs-realtime.js

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -42,8 +42,8 @@ request(requestSettings, function (error, response, body) {
   if (!error && response.statusCode == 200) {
     var feed = GtfsRealtimeBindings.transit_realtime.FeedMessage.decode(body);
     feed.entity.forEach(function(entity) {
-      if (entity.trip_update) {
-        console.log(entity.trip_update);
+      if (entity.tripUpdate) {
+        console.log(entity.tripUpdate);
       }
     });
   }


### PR DESCRIPTION
Hi folks,
I figured out, running the example code with node.js, that the symbol for the feed message entity 'trip update' is not used according to its definition in gtfs-realtime.js

Cheers!