### PR TITLE
feat: Publish Java Bindings to Maven Central

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,8 +6,6 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,10 @@ on:
     branches: [ master ]
     paths:
       - 'java/**'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'java/**'
 
 jobs:
   build:
@@ -15,9 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: '11'
+          distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'java/**'
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Deploy with Maven
+        working-directory: ./java
+        run: mvn -B clean deploy -Pci-cd
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,6 @@ on:
     branches: [ master ]
     paths:
       - 'java/**'
-  pull_request:
-    branches: [ master ]
-    paths:
-      - 'java/**'
 
 jobs:
   build:

--- a/java/README.md
+++ b/java/README.md
@@ -17,9 +17,9 @@ dependencies section:
 
 ```xml
 <dependency>
-  <groupId>io.mobilitydata.transit</groupId>
+  <groupId>org.mobilitydata</groupId>
   <artifactId>gtfs-realtime-bindings</artifactId>
-  <version>0.0.7</version>
+  <version>0.0.8-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/java/README.md
+++ b/java/README.md
@@ -27,7 +27,7 @@ For [Gradle](https://www.gradle.org/), add the following to your `build.gradle`
 dependecies section:
 
 ```
-compile group: 'io.mobilitydata.transit', name: 'gtfs-realtime-bindings', version: '0.0.8-SNAPSHOT'
+compile group: 'org.mobilitydata', name: 'gtfs-realtime-bindings', version: '0.0.8-SNAPSHOT'
 ```
 
 Make sure the Maven central repository is referenced by your project.

--- a/java/README.md
+++ b/java/README.md
@@ -1,6 +1,6 @@
 # Java GTFS-realtime Language Bindings
 
-![Maven Central Version](https://img.shields.io/maven-central/v/io.mobilitydata.transit/gtfs-realtime-bindings.svg)
+![Maven Central Version](https://img.shields.io/maven-central/v/org.mobilitydata/gtfs-realtime-bindings.svg)
 
 Provides Java classes generated from the [GTFS-realtime](https://github.com/google/transit/tree/master/gtfs-realtime)
 Protocol Buffer specification.  These classes will allow you to parse a binary Protocol Buffer
@@ -27,7 +27,7 @@ For [Gradle](https://www.gradle.org/), add the following to your `build.gradle`
 dependecies section:
 
 ```
-compile group: 'io.mobilitydata.transit', name: 'gtfs-realtime-bindings', version: '0.0.7'
+compile group: 'io.mobilitydata.transit', name: 'gtfs-realtime-bindings', version: '0.0.8-SNAPSHOT'
 ```
 
 Make sure the Maven central repository is referenced by your project.

--- a/java/README.md
+++ b/java/README.md
@@ -61,3 +61,17 @@ For more details on the naming conventions for the Java classes generated from
 the [gtfs-realtime.proto](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto),
 check out the [Java Generated Code](https://developers.google.com/protocol-buffers/docs/reference/java-generated)
 section of the Protocol Buffers developer site.
+
+## Project History
+
+### `0.0.4` and lower
+This project was originally created by Google. You can download versions `0.0.4` and older under the Group ID `com.google.transit` [here on Maven Central](https://search.maven.org/search?q=g:com.google.transit%20AND%20a:gtfs-realtime-bindings).
+
+### `0.0.5`
+MobilityData started to maintain the project in early 2019 and initially published release artifacts via JCenter. You can download version `0.0.5` under the Group ID `io.mobilitydata.transit` [here on Maven Central](https://search.maven.org/artifact/io.mobilitydata.transit/gtfs-realtime-bindings).
+
+### `0.0.6` and `0.0.7`
+JCenter [shut down](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) in 2021. Prior to the shutdown, a synchronization problem prevented versions `0.0.6` and `0.0.7` from being synchronized from JCenter to Maven Central, so direct artifact download is not currently available for these versions. However, you can compile them yourself from the [tags](https://github.com/MobilityData/gtfs-realtime-bindings/tags) using the command `mvn package`.
+
+### `0.0.8` and higher
+In 2022, MobilityData switched to publishing artifacts directly to Maven Central under the Group ID `org.mobilitydata`, which is where versions 0.0.8 and higher are published.

--- a/java/UPDATING.md
+++ b/java/UPDATING.md
@@ -26,58 +26,32 @@ Test the generated code:
 mvn verify
 ````
 
-## Publishing a new release
+## Publishing a new release.
 
 #### One-Time Setup
 
-We're hosting releases on JCenter via [Bintray](https://bintray.com/).
+We're hosting releases on the [Maven Central Repository](http://search.maven.org/).
 
-These are the steps for publishing the `gtfs-realtime-bindings` library on `jcenter` repository.
+Note that we are using GitHub actions to publish new releases. These are the [steps](https://dzone.com/articles/how-to-publish-artifacts-to-maven-central) that were followed for publishing the `gtfs-realtime-bindings` library on `ossrh` repository using GitHub actions.
 
-###### 1 - Create an account on [Bintray](https://bintray.com/).
-###### 2 - Setup your pom.xml
-
-We need to specify the URL from which to distribute your project. 
-```
-  <distributionManagement>
-    <repository>
-      <id>jCenter</id>
-      <url>https://api.bintray.com/maven/mobilitydata/mobilitydata-mvn-repo/gtfs-realtime-bindings/;publish=1</url>
-    </repository>
-  </distributionManagement>
-```
-
-###### 3 - Setup your setting.xml
-We need to provide Bintray username and API Key to the Maven `settings.xml` file.  This may be under your Maven installation directory (e.g., `C:\Program Files\Apache Software Foundation\apache-maven-3.2.5\conf`).
-
-```
-<server>
-  <id>jCenter</id>
-  <username>yourjcenteraccount</username>
-  <password>***youraccount-secret-api-key***</password>
-</server>
-```
-
-To sign the application (required for publishing to Maven Central) we use Bintray's automated signing using their internal key as discussed [here](https://www.jfrog.com/confluence/display/BT/Managing+Uploaded+Content#ManagingUploadedContent-SigningwiththeBintrayKey). So, no certificate setup for signing is required.
+To sign the application (required for publishing to Maven Central) we use a GPG key as described [here](https://dzone.com/articles/how-to-publish-artifacts-to-maven-central#:~:text=%3C/servers%3E-,GPG%20Setup,-You%E2%80%99ll%20have%20to).
 
 #### Every release
 
-1. After you've committed any changes, run `mvn release:prepare -Dresume=false`.  This will automatically bump the SNAPSHOT version number to the release version, commit this change, and then bump the version number again to the new SNAPSHOT version for the next development cycle and commit this change too. After running `mvn release:prepare` you'll be prompted to enter these version numbers as well as the tag release name - use the following values, where X is the new version to be released (e.g., if current version is `0.0.1-SNAPSHOT`, release would be `0.0.1`):
+1. Create a new branch from the master branch where you will commit your changes.
+   `git checkout -b your/new/branch`
+
+2. After you've committed any changes, run `mvn release:prepare -Dresume=false`.  This will automatically bump the SNAPSHOT version number to the release version, commit this change, and then bump the version number again to the new SNAPSHOT version for the next development cycle and commit this change too. After running `mvn release:prepare` you'll be prompted to enter these version numbers as well as the tag release name - use the following values, where X is the new version to be released (e.g., if current version is `0.0.1-SNAPSHOT`, release would be `0.0.1`):
    	
    * `0.0.[X]`
    * `gtfs-realtime-bindings-java-0.0.[X]` (Note the addition of `-java`)
    * `0.0.[X+1]-SNAPSHOT`
    
-1. Checkout the release commit:
-
-   * `git checkout gtfs-realtime-bindings-java-0.0.[X]`
-
-1. Deploy the artifacts to JCenter (which will automatically sync with Maven Central):
-
-    ```
-    mvn deploy
-    ```
+3. Open a pull request using your branch and request a review. The release will be automatically published when your pull request is merged in the master branch.
     
-1. Check out the master branch again to continue development:
+4. Check out the master branch and pull the changes to continue development:
    
-   `git checkout master` 
+   ```
+   git checkout master
+   git pull
+   ``` 

--- a/java/UPDATING.md
+++ b/java/UPDATING.md
@@ -38,20 +38,4 @@ To sign the application (required for publishing to Maven Central) we use a GPG 
 
 #### Every release
 
-1. Create a new branch from the master branch where you will commit your changes.
-   `git checkout -b your/new/branch`
-
-2. After you've committed any changes, run `mvn release:prepare -Dresume=false`.  This will automatically bump the SNAPSHOT version number to the release version, commit this change, and then bump the version number again to the new SNAPSHOT version for the next development cycle and commit this change too. After running `mvn release:prepare` you'll be prompted to enter these version numbers as well as the tag release name - use the following values, where X is the new version to be released (e.g., if current version is `0.0.1-SNAPSHOT`, release would be `0.0.1`):
-   	
-   * `0.0.[X]`
-   * `gtfs-realtime-bindings-java-0.0.[X]` (Note the addition of `-java`)
-   * `0.0.[X+1]-SNAPSHOT`
-   
-3. Open a pull request using your branch and request a review. The release will be automatically published when your pull request is merged in the master branch.
-    
-4. Check out the master branch and pull the changes to continue development:
-   
-   ```
-   git checkout master
-   git pull
-   ``` 
+TODO

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
         <version>9</version>
     </parent>
 
-    <groupId>io.mobilitydata.transit</groupId>
+    <groupId>org.mobilitydata</groupId>
     <artifactId>gtfs-realtime-bindings</artifactId>
     <version>0.0.8-SNAPSHOT</version>
 
@@ -49,6 +49,16 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <id>maximearmstrong</id>
+            <name>Maxime Armstrong</name>
+            <email>maxime@mobilitydata.org</email>
+            <organization>MobilityData</organization>
+            <organizationUrl>http://www.mobilitydata.org</organizationUrl>
+        </developer>
+    </developers>
 
     <dependencies>
         <dependency>
@@ -123,11 +133,48 @@
             </plugin>
         </plugins>
     </build>
+
     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>s01.oss.sonatype.org</url>
+        </snapshotRepository>
         <repository>
-            <id>jCenter</id>
-            <url>https://api.bintray.com/maven/mobilitydata/mobilitydata-mvn-repo/gtfs-realtime-bindings/;publish=1
-            </url>
+            <id>ossrh</id>
+            <url>s01.oss.sonatype.org</url>
         </repository>
     </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>ci-cd</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing
+                                        failed: Inappropriate ioctl for device -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -137,11 +137,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>s01.oss.sonatype.org</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>s01.oss.sonatype.org</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Fixes #80.

- Modifies `./java/pom.xml` to prepare to publish to Maven Central.
- Adds `maven.yml` workflow to publish to Maven Central.

Sonatype ticket:
https://issues.sonatype.org/browse/OSSRH-79283