### PR TITLE
Pin the Python protobuf dependency (#71)

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -32,10 +32,10 @@ if __name__ == '__main__':
   ext_module_list = []
 
   setup(name = 'gtfs-realtime-bindings',
-        version = '0.0.7',
+        version = '0.0.8',
         packages = ['google', 'google.transit'],
         namespace_packages = ['google'],
-        install_requires = ['setuptools', 'protobuf'],
+        install_requires = ['setuptools', 'protobuf>=3, <4'],
         url = 'https://github.com/MobilityData/gtfs-realtime-bindings',
         maintainer = 'MobilityData',
         maintainer_email = 'gtfs-realtime@googlegroups.com',


### PR DESCRIPTION
The Python protobuf library was updated tonight in a backwards incompatible
way, and the Python bindings are no longer working for fresh builds. I tried
to upgrade the bindings but couldn't get the tests to pass. As a workaround,
this commit just pins the version of the Python protobuf package to something
less than 4.