### PR TITLE
docs: Fix chat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# gtfs-realtime-bindings
-[![Join the MobilityData chat](https://bit.ly/mobilitydata-slack)](https://bit.ly/mobilitydata-slack)
+# gtfs-realtime-bindings [![Join the MobilityData chat](https://img.shields.io/badge/chat-on%20slack-red)](https://bit.ly/mobilitydata-slack)
 
 Language bindings generated from the
 [GTFS Realtime](https://github.com/google/transit/tree/master/gtfs-realtime) protocol


### PR DESCRIPTION
The current image for chat badge on the README doesn't render correctly:

![image](https://user-images.githubusercontent.com/928045/171685895-1f2f771c-385c-4c93-851b-64f8e1c71442.png)

This PR fixes it using a badge from https://shields.io/category/chat:

![image](https://user-images.githubusercontent.com/928045/171685911-a7ca5a2e-eb47-4ec3-8243-d7a0b63299f4.png)