### PR TITLE
feat: Updates the java bindings version to 0.0.9-SNAPSHOT

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.mobilitydata</groupId>
     <artifactId>gtfs-realtime-bindings</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9-SNAPSHOT</version>
 
     <name>gtfs-realtime-bindings</name>
     <description>Java classes generated from the GTFS-realtime protocol buffer specification.</description>


### PR DESCRIPTION
Updates version to 0.0.9-SNAPSHOT in `./java/pom.xml`.
`./java/README.md` isn't updated to keep release version 0.0.8 in the examples.
