### PR TITLE
fix nodejs readme typos

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -11,7 +11,7 @@ These bindings are designed to be used in the [Node.js](http://nodejs.org/)
 environment, but with some effort, they can probably be used in other
 JavaScript environments as well.
 
-We use the [ProtBuf.js](https://github.com/dcodeIO/ProtoBuf.js) library for
+We use the [ProtoBuf.js](https://github.com/dcodeIO/ProtoBuf.js) library for
 JavaScript Protocol Buffer support.
 
 ## Add the Dependency
@@ -50,7 +50,7 @@ request(requestSettings, function (error, response, body) {
 });
 ```
 
-For more details on the naming conventions for the Javascript classes generated
+For more details on the naming conventions for the JavaScript classes generated
 from the
 [gtfs-realtime.proto](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto),
 check out the [ProtoBuf.js project](https://github.com/dcodeIO/ProtoBuf.js/wiki)


### PR DESCRIPTION
I noticed a couple of typos in the documentation, so I decided to put up a quick fix for them!