### PR TITLE
Proposal: javascript: timestamps as numbers instead of int64 type representation

### DIFF
--- a/nodejs/gtfs-realtime.js
+++ b/nodejs/gtfs-realtime.js
@@ -389,7 +389,7 @@ $root.transit_realtime = (function() {
                     message.incrementality = reader.int32();
                     break;
                 case 3:
-                    message.timestamp = reader.uint64();
+                    message.timestamp = new $util.LongBits(reader.uint64()).toNumber(true);
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -982,7 +982,7 @@ $root.transit_realtime = (function() {
                     message.stopTimeUpdate.push($root.transit_realtime.TripUpdate.StopTimeUpdate.decode(reader, reader.uint32()));
                     break;
                 case 4:
-                    message.timestamp = reader.uint64();
+                    message.timestamp = new $util.LongBits(reader.uint64()).toNumber(true);
                     break;
                 case 5:
                     message.delay = reader.int32();
@@ -1921,7 +1921,7 @@ $root.transit_realtime = (function() {
                     message.currentStatus = reader.int32();
                     break;
                 case 5:
-                    message.timestamp = reader.uint64();
+                    message.timestamp = new $util.LongBits(reader.uint64()).toNumber(true);
                     break;
                 case 6:
                     message.congestionLevel = reader.int32();
@@ -3039,10 +3039,10 @@ $root.transit_realtime = (function() {
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
                 case 1:
-                    message.start = reader.uint64();
+                    message.start = new $util.LongBits(reader.uint64()).toNumber(true);
                     break;
                 case 2:
-                    message.end = reader.uint64();
+                    message.end = new $util.LongBits(reader.uint64()).toNumber(true);
                     break;
                 default:
                     reader.skipType(tag & 7);


### PR DESCRIPTION
Currently timestamps (int64) are decoded as objects with "low", "high", and "unsigned" properties.
This PR changes this behavior.

Before:
```
{
    timestamp: {
        low: 1667665624,
        high: 0,
        unsigned: true
    }
}
```
After:
```
{
    timestamp: 1667665624
}
```