### PR TITLE
docs: improved JS example

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -36,8 +36,9 @@ const https = require("https");
 https
   .get(
     "<GTFS-realtime source URL>",
+    // replace with your GTFS-realtime source's auth token
+    // e.g. x-api-key is the header value used for NY's MTA GTFS APIs
     {
-      // replace with your GTFS-realtime source's auth token
       headers: {
         "x-api-key": "<redacted>",
       },


### PR DESCRIPTION
A couple of small improvements for the JS example:
- replacing the `request` package, [which has been deprecated](https://www.npmjs.com/package/request)
- a couple of style modernizations