### PR TITLE
improved nodejs codegen build and fixed race condition with update_ge…

### DIFF
--- a/golang/update_generated_code.sh
+++ b/golang/update_generated_code.sh
@@ -11,8 +11,10 @@ docker build -t gtfs-golang -f $GOLANG_DIR/Dockerfile $PROJECT_ROOT_DIR
 # run the docker image as an unnamed, ephemeral container to ensure protoc and unit test execution succeeds
 # specify -it so that we can ctrl-c kill if something gets stuck
 docker run -it gtfs-golang
-# run the docker image as a named container running as a daemon (-d)
-docker run --name gtfs-golang-container -it -d gtfs-golang
+# run the docker image as a named container running as a daemon (-d) that runs forever until killed
+docker run --name gtfs-golang-container -it -d gtfs-golang tail -f > /dev/null
+# execute the code gen in the foreground so there is no race condition
+docker exec gtfs-golang-container protoc --go_out=./ --go_opt=Mgtfs-realtime.proto=./gtfs --proto_path=.. gtfs-realtime.proto
 # copy the file from the named container running as a daemon onto the host machine
 docker cp gtfs-golang-container:/lib/gtfs/gtfs-realtime.pb.go $GOLANG_DIR/gtfs/gtfs-realtime.pb.go
 # delete the named container

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -4,5 +4,8 @@ WORKDIR /lib
 COPY nodejs/package.json /lib/package.json
 COPY nodejs/package-lock.json /lib/package-lock.json
 COPY gtfs-realtime.proto /gtfs-realtime.proto
+RUN mkdir test
+COPY nodejs/test/test.js /lib/test/test.js
+COPY nodejs/test/vehicle_position.pb /lib/test/vehicle_position.pb
 RUN npm ci
-RUN npm run buildProto
+CMD npm run codeGen && npm run test

--- a/nodejs/UPDATING.md
+++ b/nodejs/UPDATING.md
@@ -16,23 +16,13 @@
 
 #### Re-generating the code
 
-1. Run the following from the project root folder:
+1. Run the update script:
 
     ```
-    docker build -t gtfs-nodejs -f nodejs/Dockerfile .
-    # -it to make sure docker run can be killed with ctrl-c
-    # -t uses TTY, which causes linux to include carriage returns, which are stripped using tr
-    docker run -it --rm gtfs-nodejs cat /lib/gtfs-realtime.js | tr -d '\r' > nodejs/gtfs-realtime.js
-    docker run -it --rm gtfs-nodejs cat /lib/gtfs-realtime.d.ts | tr -d '\r' > nodejs/gtfs-realtime.d.ts
+    ./update_generated_code.sh
     ```
 
 1. Add the license header back to the generated source file.
-
-1. Test the generated code:
-
-    ```
-    npm run test
-    ```
 
 1. Update the version number in `package.json`.
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -17,7 +17,7 @@
     "types": "gtfs-realtime.d.ts",
     "scripts": {
         "test": "mocha test/*.js",
-        "buildProto": "pbjs -t static-module -w commonjs -o gtfs-realtime.js ../gtfs-realtime.proto && pbts -o gtfs-realtime.d.ts gtfs-realtime.js"
+        "codeGen": "pbjs -t static-module -w commonjs -o gtfs-realtime.js ../gtfs-realtime.proto && pbts -o gtfs-realtime.d.ts gtfs-realtime.js"
     },
     "engines": {
         "node": "18.12.1"

--- a/nodejs/update_generated_code.sh
+++ b/nodejs/update_generated_code.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e -x
+
+# store the directory information to allow the script to be executed from anywhere
+NODEJS_DIR=$(cd `dirname $0` && pwd)
+PROJECT_ROOT_DIR=$(dirname "$NODEJS_DIR")
+
+# check to see if there is a leftover docker image with this tag to clean up
+docker rmi -f gtfs-nodejs
+# build and tag the docker image
+docker build -t gtfs-nodejs -f $NODEJS_DIR/Dockerfile $PROJECT_ROOT_DIR
+# run the docker image as an unnamed, ephemeral container to ensure protoc and unit test execution succeeds
+# specify -it so that we can ctrl-c kill if something gets stuck
+docker run -it gtfs-nodejs
+# run the docker image as a named container running as a daemon (-d) that runs forever until killed
+docker run --name gtfs-nodejs-container -d -it gtfs-nodejs tail -f > /dev/null
+# execute the code gen in the foreground so there is no race condition
+docker exec gtfs-nodejs-container npm run codeGen
+# copy the files from the named container running as a daemon onto the host machine
+docker cp gtfs-nodejs-container:/lib/gtfs-realtime.js $NODEJS_DIR/gtfs-realtime.js
+docker cp gtfs-nodejs-container:/lib/gtfs-realtime.d.ts $NODEJS_DIR/gtfs-realtime.d.ts
+# delete the named container
+docker rm -f gtfs-nodejs-container


### PR DESCRIPTION
- brought the `nodejs` codegen build up to par with the `golang` codegen build
- in testing the `nodejs` codegen, I actually happened upon a bug in the `golang` implementation. `docker run -d` backgrounds the entire docker container, which means that there is no guarantee that the code gen has completed prior to attempting the subsequent `docker cp` command. In addition, the container doesn't stay alive unless its foreground process stays alive. To solve for these race conditions, we override the container's original foreground process with `tail -f > /dev/null` so that it will be around until we kill it and then `exec` the code gen command synchronously prior to `cp`ing it