### PR TITLE
bugfix: remove nodejs engines requirement until further discussion with other contributors

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,7 +5,7 @@
     "tags": [
         "gtfs-realtime"
     ],
-    "version": "1.1.0",
+    "version": "1.1.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/MobilityData/gtfs-realtime-bindings.git"
@@ -18,9 +18,6 @@
     "scripts": {
         "test": "mocha test/*.js",
         "buildProto": "pbjs -t static-module -w commonjs -o gtfs-realtime.js ../gtfs-realtime.proto && pbts -o gtfs-realtime.d.ts gtfs-realtime.js"
-    },
-    "engines": {
-        "node": "18.12.1"
     },
     "dependencies": {
         "protobufjs": "^7.1.2",


### PR DESCRIPTION
- I had initially added the `engines` requirement when thinking about how to lock down the Node runtime for code-gen
- However, I failed to realize that the `engines` requirement would be applied for usages of the published package as well
- We should probably establish a reasonable `engines` minimum requirement still (open to suggestions), but I already published this as a patch fix in order to unbreak the published npm package
- Using `engines` to lock down the code-gen Node runtime is also unnecessary now, since the base docker image will take care of that for us