### PR TITLE
chore(python): add Python GitHub workflows

### DIFF
--- a/.github/workflows/python-pr.yml
+++ b/.github/workflows/python-pr.yml
@@ -17,8 +17,6 @@ jobs:
       package-path: 'python'
       test-path: 'tests'
       debug: false
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check_version_bump:
     name: Check version bump in pyproject.toml

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -12,8 +12,6 @@ jobs:
       package-path: 'python'
       test-path: 'tests'
       debug: false
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_and_publish:
     name: Build & Publish

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,9 +21,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      GITHUB_TOKEN:
-        required: false
 
 jobs:
   test:


### PR DESCRIPTION
# Description
This PR introduces minimal automation of Python's PRs and releases. The release action will be tested after merging and might need some tweaks afterward. In this PR, the Python package version is _intentionally not bumped_. It will be bumped when the full CI is tested and ready for prime time. 

# From our AI friend
This pull request introduces a new set of GitHub Actions workflows to automate Python package testing and release processes. The main changes are the addition of reusable workflows for running tests on multiple Python versions, checking for version bumps in `pyproject.toml` during pull requests, and building and publishing the package to PyPI during releases.

**CI/CD Workflow Additions:**

* Added `.github/workflows/python-test.yml` as a reusable workflow to run Python tests across multiple versions, with configurable inputs for package and test paths, and optional debug output.

**Pull Request Checks:**

* Created `.github/workflows/python-pr.yml` to run tests via the reusable workflow and check if the package version in `python/pyproject.toml` was bumped in pull requests, warning if not.

**Release Automation:**

* Introduced `.github/workflows/python-release.yml` to run tests and, upon success, build and publish the Python package to PyPI using trusted publishing via GitHub Actions.