### PR TITLE
Fix: upgrade 1password/load-secrets-action from v2.0.0 to v4.0.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Load secrets from 1Password
         id: onepw_secrets
-        uses: 1password/load-secrets-action@v2.0.0
+        uses: 1password/load-secrets-action@v4.0.0
         with:
           export-env: true # Export loaded secrets as environment variables
         env:


### PR DESCRIPTION
Upgrades 1password/load-secrets-action from v2.0.0 to v4.0.0 in the Maven CI workflow. 
GitHub's CDN (codeload.github.com) is currently not serving the archive for the v2.0.0 release, causing the workflow to fail at setup. 
It could be a temporary problem in the Github side, but we might as well try the newer version.
No functional changes — v4.0.0 is fully compatible with this workflow.
