### PR TITLE
fix(ruby): use valid SPDX license identifier in gemspec

### DIFF
--- a/ruby/gtfs-realtime-bindings.gemspec
+++ b/ruby/gtfs-realtime-bindings.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["gtfs-realtime@googlegroups.com"]
   spec.homepage      = "https://github.com/MobilityData/gtfs-realtime-bindings"
   spec.summary       = %q{Ruby classes generated from the GTFS-realtime protocol buffer specification.}
-  spec.license       = 'Apache License, Version 2.0'
+  spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
`gem build` currently warns:

```
WARNING:  License identifier 'Apache License, Version 2.0' is invalid. Use an identifier from
https://spdx.org/licenses ... Did you mean 'Apache-2.0'?
```

This sets `spec.license` to the valid SPDX id `Apache-2.0` (same license, correct metadata), so the gem build in `release.yml` is warning-free.

No version bump — the gem is still at 0.1.0 (unpublished), so this rides along when 0.1.0 first publishes. That publish is currently blocked on gem ownership (#172); this is unrelated cleanup surfaced by the same build.